### PR TITLE
Remove custom builder link

### DIFF
--- a/src/commands/deepsea.ts
+++ b/src/commands/deepsea.ts
@@ -29,11 +29,12 @@ export default new Command({
       releases.forEach((e) => {
         fields.push({name:`${e.name.split(".")[0]}`, value:`[Download](<https://github.com/Team-Neptune/DeepSea/releases/download/${e.latestTag}/${e.name}>)`, inline:false})
       })
-      fields.push({
-        "name":"Custom package",
-        'value':"[Build your own DeepSea package](https://builder.teamneptune.net)",
-        "inline":false
-      })
+      // Disabled until uptime reliability increases
+      // fields.push({
+      //   "name":"Custom package",
+      //   'value':"[Build your own DeepSea package](https://builder.teamneptune.net)",
+      //   "inline":false
+      // })
       interaction.reply({
           embeds:[
               {


### PR DESCRIPTION
The link for the custom builder in `/deepsea` is removed until uptime reliability increases.